### PR TITLE
Added: `skipTransform` config setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Imgix Asset Transformer for Craft CMS
 
+## Unreleased
+
+- Added: `skipTransform` config setting to skip imgix transforms for specific assets. Useful for excluding non-image assets like PDFs.
+
 ## 5.0.0-alpha.7 - 2025-09-22
 
 - Fixed: `ratio` for CraftCMS v5.8+

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Copy config.php into Crafts config folder and rename it to newism-imgix.php.
 cp vendor/newism/craft-imgix/src/config.php config/newism-imgix.php
 ```
 
-Update the `imgixDomain` settings key with your imgix domain.
+Update the `imgixDomain` config setting key with your imgix domain.
 
 ## Usage
 

--- a/src/config.php
+++ b/src/config.php
@@ -3,28 +3,41 @@
 use craft\helpers\App;
 
 return [
+    // Your imgix source domain.
+    'imgixDomain' => App::env('CRAFT_IMGIX_DOMAIN') ?? 'your-domain.imgix.net',
+
     // With this setting enabled, the plugin will overlay transform information on the image.
     'devMode' => App::env('CRAFT_IMGIX_DEV_MODE') ?? Craft::$app->config->general->devMode,
 
+    // Globally enable or disable the plugin.
     'enabled' => App::env('CRAFT_IMGIX_ENABLED') ?? true,
 
-    'imgixDomain' => App::env('CRAFT_IMGIX_DOMAIN') ?? 'your-domain.imgix.net',
-
+    // The signing key for secure URLs. Leave blank to disable URL signing.
     'signingKey' => App::env('CRAFT_IMGIX_SIGNING_KEY') ?? '',
 
+    // An optional callback that defines whether to skip the transform logic.
+    // The callback will be passed the Asset and the ImageTransform (or null if no transform is being applied).
+    // Return true to skip the transform logic and return the URL defined in the asset Filesystem.
+    // Example: skip non-image assets when no transform is applied
+//    'skipTransform' => function(\craft\elements\Asset $asset, ?\craft\models\ImageTransform $transform = null) {
+//        return $asset->kind !== 'image' && $transform === null;
+//    },
+
     // Default imgix parameters that will be applied to all images unless overridden.
-    //'imgixDefaultParams' => [
-    //    'auto' => 'format,compress',
-    //    'cs' => 'srgb',
-    //],
+//    'imgixDefaultParams' => [
+//        'auto' => 'format,compress',
+//        'cs' => 'srgb',
+//    ],
 
       // Override settings for each volume
-//    'volumes' => [
-//        'volume handle goes here' => [
-//             'devMode' => '',
-//             'enabled' => '',
-//             'imgixDomain' => '',
-//             'imgixDefaultParams' => [],
-//        ],
-//    ]
+// 'volumes' => [
+//     'volume handle goes here' => [
+//          'devMode' => '',
+//          'enabled' => '',
+//          'imgixDomain' => '',
+//          'imgixDefaultParams' => [],
+//     ],
+// ]
+
+
 ];

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -11,8 +11,9 @@ class Settings extends Model
 {
     public bool $devMode = false;
     public bool $enabled = true;
-    public ?string $imgixDomain = null;
+    public string $imgixDomain = '';
     public array $imgixDefaultParams = [];
     public string $signingKey = '';
+    public mixed $skipTransform = false;
     public array $volumes = [];
 }

--- a/src/services/ImgixService.php
+++ b/src/services/ImgixService.php
@@ -22,6 +22,7 @@ class ImgixService extends ServiceLocator
 
     public function generateUrl(Asset $asset, mixed $transform = null): ?string
     {
+
         /**
          * Check for temp fs and return null if it is allowing Craft CMS to handle the transform
          */
@@ -42,9 +43,26 @@ class ImgixService extends ServiceLocator
             return null;
         }
 
-        $defaultImgixParams = is_callable($volumeSettings->imgixDefaultParams)
-            ? $volumeSettings->imgixDefaultParams($asset, $transform)
-            : ($volumeSettings->imgixDefaultParams ?? []);
+        $transform = ImageTransforms::normalizeTransform($transform);
+
+        $skipTransform = false;
+        if (isset($volumeSettings->skipTransform)) {
+            $skip = $volumeSettings->skipTransform;
+            $skipTransform = is_callable($skip)
+                ? $skip($asset, $transform)
+                : (bool)$skip;
+        }
+        if($skipTransform) {
+            return null;
+        }
+
+        $defaultImgixParams = [];
+        if (isset($volumeSettings->imgixDefaultParams)) {
+            $params = $volumeSettings->imgixDefaultParams;
+            $defaultImgixParams = is_callable($params)
+                ? $params($asset, $transform)
+                : (array)$params;
+        }
 
         $httpQueryParams = $defaultImgixParams;
 
@@ -53,7 +71,6 @@ class ImgixService extends ServiceLocator
         $httpQueryParams['fp-y'] = $cropPosition['y'] ?? null;
         $httpQueryParams['fp-debug'] = $volumeSettings->devMode ?: null;
 
-        $transform = ImageTransforms::normalizeTransform($transform);
 
         // If we have a transform we add the imgix params
         if ($transform) {
@@ -190,6 +207,7 @@ class ImgixService extends ServiceLocator
             'enabled' => $settings->enabled,
             'imgixDomain' => $settings->imgixDomain,
             'signingKey' => $settings->signingKey,
+            'skipTransform' => $settings->skipTransform,
             'imgixDefaultParams' => $settings->imgixDefaultParams,
         ], $settings->volumes[$volume->handle] ?? []);
 


### PR DESCRIPTION
Added: `skipTransform` config setting to skip imgix transforms for specific assets. Useful for excluding non-image assets like PDFs.